### PR TITLE
replace set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,10 +77,10 @@ runs:
         declare RESULT=$(git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }})
         echo $RESULT
         if echo $RESULT | grep '.changes/unreleased/.*.yaml'; then
-          echo "::set-output name=exists::true"
+          echo "exists::true" >> $GITHUB_OUTPUT
           echo "Changelog already exists for this PR, skip creating a new one"
         else
-          echo "::set-output name=exists::false"
+          echo "exists::false" >> $GITHUB_OUTPUT
           echo "No changelog exists for this PR, creating a new one"
         fi
 


### PR DESCRIPTION
set-output will be deprecated end of month.  this upgrades per the [github blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)